### PR TITLE
Fix: use default EMAIL_BACKEND in welcome-email task

### DIFF
--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives, get_connection
 from django.template.loader import render_to_string
 
 User = get_user_model()
@@ -9,37 +9,37 @@ User = get_user_model()
 
 @shared_task
 def send_welcome_email(user_id):
-    print("🐞 [DEBUG] EMAIL_BACKEND =", settings.EMAIL_BACKEND)
-    print("🐞 [DEBUG] SENDGRID_API_KEY =", bool(settings.SENDGRID_API_KEY))
-    print("🐞 [DEBUG] DEFAULT_FROM_EMAIL =", settings.DEFAULT_FROM_EMAIL)
+    # Fetch the user; exit early if not found
     try:
         user = User.objects.get(pk=user_id)
     except User.DoesNotExist:
         return f"User {user_id} not found"
 
+    # Prepare template context
     context = {
         "user": user,
-        "domain": settings.DEFAULT_DOMAIN,
-        "protocol": settings.DEFAULT_PROTOCOL,
-    }
-
-    domain = getattr(settings, "DEFAULT_DOMAIN", "example.com")
-    protocol = getattr(settings, "DEFAULT_PROTOCOL", "https")
-    context = {
-        "user": user,
-        "domain": domain,
-        "protocol": protocol,
+        "domain": getattr(settings, "DEFAULT_DOMAIN", "example.com"),
+        "protocol": getattr(settings, "DEFAULT_PROTOCOL", "https"),
     }
 
     subject = "Welcome to EcommerceAPI!"
-    html_message = render_to_string("users/email/welcome.html", context)
-    text_message = render_to_string("users/email/welcome.txt", context)
+    html_content = render_to_string("users/email/welcome.html", context)
+    text_content = render_to_string("users/email/welcome.txt", context)
 
-    send_mail(
-        subject,
-        text_message,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email],
-        html_message=html_message,
+    # Obtain the default mail connection (respects settings.EMAIL_BACKEND)
+    connection = get_connection()
+
+    # Build multipart email
+    email = EmailMultiAlternatives(
+        subject=subject,
+        body=text_content,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[user.email],
+        connection=connection,
     )
+    email.attach_alternative(html_content, "text/html")
+
+    # Send the email
+    email.send(fail_silently=False)
+
     return f"Welcome email sent to {user.email}"


### PR DESCRIPTION
Welcome email task was falling back on general Django settings, because of 'django.core.mail.send_mail()'. Task updated so it selects the right email backend depending on DEBUG = False/True.